### PR TITLE
Fix SpanEvent maximum name length

### DIFF
--- a/src/Wrappers/SpanEvent.php
+++ b/src/Wrappers/SpanEvent.php
@@ -131,6 +131,8 @@ class SpanEvent
      */
     public function setSpanName(string $name)
     {
+        $name = strlen($name) > 1024 ? substr($name, 0, 1021).'...' : $name;
+
         $this->span->setName($name);
     }
 


### PR DESCRIPTION
In regard to the json schema used by ELK APM, having a name longer than 1024 chars is not accepted. This case can easily occur if we use our SQL query to name the span.

This PR truncates the span name accordingly.