### PR TITLE
Use RUM header to allow distributed tracing

### DIFF
--- a/src/Wrappers/Traits/EventTrait.php
+++ b/src/Wrappers/Traits/EventTrait.php
@@ -69,7 +69,7 @@ trait EventTrait
     {
         // Generate Random UUIDs
         $this->id = UID::Generate(16);       //Uuid::uuid4()->toString();
-        $this->trace_id = UID::Generate(16); //Uuid::uuid4()->toString();
+        $this->trace_id = $this->trace_id = $_SERVER['HTTP_ELASTIC_APM_TRACEPARENT'] ? : UID::Generate(16); //Uuid::uuid4()->toString();
 
         // Set Shared Context Variable for further use
         $this->sharedData = $sharedData;


### PR DESCRIPTION
Hey there,

It looks like the application has no support for Real-User-Monitoring header.
I added it the same way other agents set it. I tested it by forcing the header in a curl call and it worked at the APM side.

I will test with a frontend application in a few hours if I have time or in the next days.
If you have an app to do so, let me know.